### PR TITLE
Buildntest upgrades

### DIFF
--- a/buildntest.sh
+++ b/buildntest.sh
@@ -1,22 +1,89 @@
 #!/bin/sh
-#set -x
+#set -x # uncomment this to have the shell output the commands before they are ran
 
-mkdir -p "tmp.dockerWorkArea"
-if [ "$?" -ne 0 ]; then
+if ! mkdir -p "tmp.dockerWorkArea"; then
     echo "ERROR: Unable to create 'tmp.dockerWorkArea' directory." >&2
+    exit 1
 fi
 
-( cd src && CGO_ENABLED=0 go build -o ../tmp.dockerWorkArea/reaper )
-if [ "$?" -ne 0 ]; then
+baseDir=$(pwd)
+
+if ! cd src; then
     echo "ERROR: Unable to cd into 'tmp.dockerWorkArea' and build the binary." >&2
+    exit 1
 fi
 
-which go
-if [ "$?" -ne 0 ]; then
+if ! CGO_ENABLED=0 go build -v -o ../tmp.dockerWorkArea/reaper; then
+    echo "ERROR: Unable to cd into 'tmp.dockerWorkArea' and build the binary." >&2
+    exit 1
+fi
+
+if ! which go; then
     echo "ERROR: Unable to find the go compiler." >&2
+    exit 1
 fi
 
-( cd tmp.dockerWorkArea && cp -a ../Dockerfile ./ && docker build -t reaper:1 . )
+cd $baseDir
 
-kind load docker-image reaper:1
+if ! cp -a Dockerfile tmp.dockerWorkArea/; then
+    echo "ERROR: Unable to copy the Dockerfile." >&2
+    exit 1
+fi
+
+if ! cd tmp.dockerWorkArea; then
+    echo "ERROR: Unable to build the docker image." >&2
+    exit 1
+fi
+
+if ! docker build -f Dockerfile -t reaper:1 .; then
+    echo "ERROR: Unable to build the docker image." >&2
+    exit 1
+fi
+
+if ! docker image save reaper:1 -o reaper-1.dockerImage.tar; then
+    echo "ERROR: Unable save out the docker image." >&2
+    exit 1
+fi
+
+cd $baseDir
+
+# microk8s is micro kubernetes: https://microk8s.io/
+if which microk8s.kubectl; then
+    if ! microk8s.ctr image import ./tmp.dockerWorkArea/reaper-1.dockerImage.tar; then
+        echo "ERROR: Unable to load the docker image into microk8s." >&2
+        exit 1
+    fi
+
+    if ! microk8s.ctr images ls|grep "SIZE\|reaper"; then
+        echo "ERROR: Unable to load the docker image into microk8s." >&2
+        exit 1
+    fi
+
+    echo "INFO: The image for reaper was successfully imported into microk8s to create containers from."
+
+    echo "INFO: Now attempting to start reaper in microk8s."
+
+    # start/replace reaper in microk8s
+    microk8s kubectl replace --force -f manifest.yaml
+
+    # stop reaper in microk8s
+    #microk8s kubectl delete -f manifest.yaml
+
+elif which kind; then
+    # kind is kubernetes in docker: https://kind.sigs.k8s.io/
+    if ! kind load docker-image reaper:1; then
+        echo "ERROR: Unable to load the docker image into kind." >&2
+        exit 1
+    fi
+    
+    echo "INFO: The image for reaper was successfully imported into kind to create containers from."
+else
+    echo "ERROR: Unable to find microk8s or kind to load the image into." >&2
+    exit 1
+fi
+
+echo "INFO: Deleting tmp.dockerWorkArea/ because we care."
+rm -rf tmp.dockerWorkArea/
+
+exit 0
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reaper-deployment
+  labels:
+    app: reaper
+spec:
+  selector:
+    matchLabels:
+      app: reaper
+  template:
+    metadata:
+      labels:
+        app: reaper
+    spec:
+      containers:
+      - name: reaper
+        image: reaper:1
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 8443
+          


### PR DESCRIPTION
- Added temp manifest.yaml file, for proof of concept of starting reaper instance in microk8s, complete with starting reaper in microk8s.
- Improved buildntest.sh failure testing.

Still need to prove some of these same commands using `kind`.