### PR TITLE
Readme detail and dedupe of kind create cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Reaper is a daemon that automatically deletes items in a Kubernetes namespace th
 ## How Reaper Works
 
 - Reaper works through setting labels on namespaces.
-- When a namespace is labelled with `reaper.io/enabled=True`, the reaper daemon will begin monitoring the objects in that namespace to check if their creation timestamp, is passed the allocated time interval.
+- When a namespace is labeled with `reaper.io/enabled=True`, the reaper daemon will begin monitoring the objects in that namespace to check if their creation timestamp, is passed the allocated time interval.
 - Many configuration parameters can be overridden on a per namespace level.
 
 ## Caveats

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ grep "^complete -F __start_kubectl k$" ~/.bashrc || echo "complete -F __start_ku
 ```
 4. If you don't have `kind` installed, use https://kind.sigs.k8s.io/docs/user/quick-start/.
 
-NOTE: If you installed `kind` v0.10.x using the default kubernetes ('kindest/node') v1.20.x image, or a version of kind `kind` where you explicitly installed the kubernetes ('kindest/mode') v1.20.x image, then you'll need to set RemoveSelfLink to false. This workaround will not work with the kubernetes ('kindest/node') v1.21.x or later images. To set RemoveSelfLink to false, run the following:
+NOTE: If you installed `kind` v0.10.x using the default kubernetes ('kindest/node') v1.20.x image, or a version of `kind` where you explicitly installed the kubernetes ('kindest/mode') v1.20.x image, then you'll need to set RemoveSelfLink to false. This workaround will not work with the kubernetes ('kindest/node') v1.21.x or later images. To set RemoveSelfLink to false, run the following:
    
 ```shell
 cat << EOF > kind.yaml

--- a/README.md
+++ b/README.md
@@ -40,14 +40,18 @@ grep '^\. ~/\.bashrc\.kubectl$' ~/.bashrc || echo '. ~/.bashrc.kubectl' >> ~/.ba
 grep "^complete -F __start_kubectl k$" ~/.bashrc || echo "complete -F __start_kubectl k" >> ~/.bashrc && . ~/.bashrc
 ```
 4. If you don't have `kind` installed, use https://kind.sigs.k8s.io/docs/user/quick-start/.
-(kind later than 1.19 requires featureGates RemoveSelfLink set to false. Use this kind yaml)
-`kind create cluster --config kind.yaml`
-```
+
+NOTE: If you installed `kind` using the default version of kubernetes ('kindest/node') v1.20.x, or a later version of kind with at least kubernetes 'kindest/node' v1.20.x, you'll need to override the new default value of RemoveSelfLink from `false` to `true`, when you create the kind cluster. If that's the case, run the following:
+   
+```shell
+cat << EOF > kind.yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   "RemoveSelfLink": false
+EOF
 ```
+
 5. If you don't have `helm` installed, use:
 
 ```shell
@@ -71,7 +75,11 @@ rm -rf linux-amd64
 which kind || echo 'export PATH=$PATH:~/bin' >> ~/.bashrc && . ~/.bashrc
 
 # create the new cluster in kind
-kind create cluster
+if [ -f kind.yaml ]; then
+    kind create cluster --config kind.yaml
+else
+    kind create cluster
+fi
 ```
 
 7. Clone Reaper & Create Reaper Namespace in Kubernetes
@@ -99,6 +107,7 @@ cd $baseDir
 ```
 
 10. Create Testing Namespaces to Monitor
+
 You can run `./test.sh` it will do the same thing as these two commands
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ grep "^complete -F __start_kubectl k$" ~/.bashrc || echo "complete -F __start_ku
 ```
 4. If you don't have `kind` installed, use https://kind.sigs.k8s.io/docs/user/quick-start/.
 
-NOTE: If you installed `kind` using the default kubernetes ('kindest/node') v1.20.x image, or you installed a later version of `kind` with the kubernetes ('kindest/node') v1.20.x image, then you'll need to set RemoveSelfLink to false, since the `selfLink` feature was deprecated in kubernetes ('kindest/node') v1.16.x and the `"RemoveSelfLink": false` workaround will be removed in kubernetes ('kindest/node') v1.21.x. To set RemoveSelfLink to false, run the following:
+NOTE: If you installed `kind` v0.10.x using the default kubernetes ('kindest/node') v1.20.x image, or a version of kind `kind` where you explicitly installed the kubernetes ('kindest/mode') v1.20.x image, then you'll need to set RemoveSelfLink to false. This workaround will not work with the kubernetes ('kindest/node') v1.21.x or later images. To set RemoveSelfLink to false, run the following:
    
 ```shell
 cat << EOF > kind.yaml

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ grep "^complete -F __start_kubectl k$" ~/.bashrc || echo "complete -F __start_ku
 ```
 4. If you don't have `kind` installed, use https://kind.sigs.k8s.io/docs/user/quick-start/.
 
-NOTE: If you installed `kind` using the default version of kubernetes ('kindest/node') v1.20.x, or a later version of kind with at least kubernetes 'kindest/node' v1.20.x, you'll need to override the new default value of RemoveSelfLink from `false` to `true`, when you create the kind cluster. If that's the case, run the following:
+NOTE: If you installed `kind` using the default kubernetes ('kindest/node') v1.20.x image, or you installed a later version of `kind` with the kubernetes ('kindest/node') v1.20.x image, then you'll need to set RemoveSelfLink to false, since the `selfLink` feature was deprecated in kubernetes ('kindest/node') v1.16.x and the `"RemoveSelfLink": false` workaround will be removed in kubernetes ('kindest/node') v1.21.x. To set RemoveSelfLink to false, run the following:
    
 ```shell
 cat << EOF > kind.yaml


### PR DESCRIPTION
- The reason for setting the RemoveSelfLink to false, is helpful to provide
- The command to create the kind cluster with the kind.yaml was being provided 2 sections too early. Adapted a logic change so that the kind cluster still gets created in the same spot as before, but with a conditional to control proper execution.